### PR TITLE
Async improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,40 @@
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+* text=auto eol=crlf
+
+# Custom for Visual Studio
+*.sln    merge=union 
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+*.cs     diff=csharp
+
+# Documents
+*.doc    diff=astextplain
+*.DOC    diff=astextplain
+*.docx   diff=astextplain
+*.DOCX   diff=astextplain
+*.dot    diff=astextplain
+*.DOT    diff=astextplain
+*.pdf    diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain
+*.md     text
+*.adoc   text
+*.textile text
+*.mustache text
+*.csv    text
+*.tab    text
+*.tsv    text
+*.sql    text
+
+# Graphics
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.svg    text

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# Roslyn cache directories
+*.ide/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/Kickstarter.Api.csproj
+++ b/Kickstarter.Api.csproj
@@ -37,6 +37,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/KickstarterClient.cs
+++ b/KickstarterClient.cs
@@ -16,7 +16,7 @@ namespace Kickstarter.Api
         {
             var session = new KickStarterSession();
 
-            var loggedOn = await session.Logon(email, password, _clientId);
+            var loggedOn = await session.Logon(email, password, _clientId).ConfigureAwait(false);
 
             // TODO: Report successful logon
 

--- a/Queries/DiscoverProjects.cs
+++ b/Queries/DiscoverProjects.cs
@@ -45,7 +45,7 @@ namespace Kickstarter.Api.Queries
 
             while(true)
             {
-                var page = await session.Get<ProjectsList>(currentUrl);
+                var page = await session.Get<ProjectsList>(currentUrl).ConfigureAwait(false);
                 results.AddRange(page.Projects);
                 numberOfProjects += page.Projects.Count();
                 if (!page.Projects.Any() || numberOfProjects >= _projectCap)

--- a/Queries/FindCategory.cs
+++ b/Queries/FindCategory.cs
@@ -16,7 +16,7 @@ namespace Kickstarter.Api.Queries
 
         public async Task<Category> ApplyTo(IKickstarterSession session)
         {
-            var categoryList = await session.Query(new AllCategories());
+            var categoryList = await session.Query(new AllCategories()).ConfigureAwait(false);
             return categoryList.Categories.FirstOrDefault(c => String.Equals(c.Name, _name, StringComparison.CurrentCultureIgnoreCase));
         }
     }


### PR DESCRIPTION
Using `ConfigureAwait(false)` causes the await to return on whatever thread is available, instead of waiting for the original thread. This is useful for libraries code such as Kickstarter.Api.

The other change is `WebClient` to `HttpClient` because `WebClient` with async is...

...buffering...
...buffering...

... slow.
